### PR TITLE
Refactor Notion API calls and improve HTTP client configuration

### DIFF
--- a/app/domain/model/slack/slack.go
+++ b/app/domain/model/slack/slack.go
@@ -43,7 +43,11 @@ func (s Slack) CreateTaskMessage(cautionTasks []task.Task, deadTasks []task.Task
 
 	message += "\n\n:space_invader: Dead Tasks :space_invader:\n"
 	for i, t := range deadTasks {
-		message += fmt.Sprintf("%d: <%s|%s> :alarm_clock:`%s`\n", i+1, t.ShortURL, t.Title, t.Due.Format("2006-01-02"))
+		due := "なるはや"
+		if t.Due != nil {
+			due = t.Due.Format("2006-01-02")
+		}
+		message += fmt.Sprintf("%d: <%s|%s> :alarm_clock:`%s`\n", i+1, t.ShortURL, t.Title, due)
 	}
 
 	return message

--- a/app/infra/dao/task.go
+++ b/app/infra/dao/task.go
@@ -17,6 +17,8 @@ import (
 
 const defaultPageSize = 100
 
+var notionHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
 type task struct {
 	NotionAPIToken   string
 	NotionDatabaseID string
@@ -30,11 +32,44 @@ func NewTask() gateway.Task {
 	}
 }
 
+func (t task) fetchTasks(ctx context.Context, body notion.FetchTasksRequestBody) (model.List, error) {
+	url := fmt.Sprintf("https://api.notion.com/v1/databases/%s/query", t.NotionDatabaseID)
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", t.NotionAPIToken))
+	req.Header.Add("Notion-Version", "2022-06-28")
+
+	res, err := notionHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	resp, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var taskDTO notion.NotionTaskDTO
+	if err := json.Unmarshal(resp, &taskDTO); err != nil {
+		return nil, err
+	}
+	return taskDTO.ToTaskListDomainModel(), nil
+}
+
 // FetchCautionAndToDoTasks : 今後1週間以内に期限が迫っているタスクと『To Do』レーンにあるタスクを取得
 // FIXME: Trello -> Notion への移行を突貫工事で作ったのでリファクタ推奨
 func (t task) FetchCautionAndToDoTasks(ctx context.Context) (model.List, error) {
-	url := fmt.Sprintf("https://api.notion.com/v1/databases/%s/query", t.NotionDatabaseID)
-
 	body := notion.FetchTasksRequestBody{
 		PageSize: defaultPageSize,
 		Filter: notion.OrFilter{
@@ -70,41 +105,10 @@ func (t task) FetchCautionAndToDoTasks(ctx context.Context) (model.List, error) 
 			{Property: "Date Created", Direction: "ascending"},
 		},
 	}
-	bodyBytes, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	payload := bytes.NewReader(bodyBytes)
-	req, err := http.NewRequest(http.MethodPost, url, payload)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", t.NotionAPIToken))
-	req.Header.Add("Notion-Version", "2022-06-28")
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer func() { _ = res.Body.Close() }()
-	resp, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var taskDTO notion.NotionTaskDTO
-	if err := json.Unmarshal(resp, &taskDTO); err != nil {
-		return nil, err
-	}
-	return taskDTO.ToTaskListDomainModel(), nil
+	return t.fetchTasks(ctx, body)
 }
 
 func (t task) FetchDeadTasks(ctx context.Context) (model.List, error) {
-	url := fmt.Sprintf("https://api.notion.com/v1/databases/%s/query", t.NotionDatabaseID)
-
 	body := notion.FetchTasksRequestBody{
 		PageSize: defaultPageSize,
 		Filter: notion.AndFilter{
@@ -126,34 +130,5 @@ func (t task) FetchDeadTasks(ctx context.Context) (model.List, error) {
 			{Property: "Date Created", Direction: "ascending"},
 		},
 	}
-	bodyBytes, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	payload := bytes.NewReader(bodyBytes)
-	req, err := http.NewRequest(http.MethodPost, url, payload)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", t.NotionAPIToken))
-	req.Header.Add("Notion-Version", "2022-06-28")
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer func() { _ = res.Body.Close() }()
-	resp, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var taskDTO notion.NotionTaskDTO
-	if err := json.Unmarshal(resp, &taskDTO); err != nil {
-		return nil, err
-	}
-	return taskDTO.ToTaskListDomainModel(), nil
+	return t.fetchTasks(ctx, body)
 }

--- a/app/infra/dto/notion/task.go
+++ b/app/infra/dto/notion/task.go
@@ -99,8 +99,13 @@ type NotionTaskDTO struct {
 }
 
 func (dto NotionTaskDTO) ToTaskListDomainModel() task.List {
-	tasks := make(task.List, len(dto.Results))
-	for i, r := range dto.Results {
+	tasks := make(task.List, 0, len(dto.Results))
+	for _, r := range dto.Results {
+		// タイトルが空のページはスキップ（panic 防止）
+		if len(r.Properties.Name.Title) == 0 {
+			continue
+		}
+
 		var deadline *time.Time
 		if r.Properties.Deadline.Date.Start != "" {
 			t, err := time.Parse("2006-01-02", r.Properties.Deadline.Date.Start)
@@ -109,16 +114,16 @@ func (dto NotionTaskDTO) ToTaskListDomainModel() task.List {
 			}
 			deadline = &t
 		}
-		title := r.Properties.Name.Title[0].PlainText
-		tasks[i] = task.Task{
-			Title:         title,
+
+		tasks = append(tasks, task.Task{
+			Title:         r.Properties.Name.Title[0].PlainText,
 			Description:   "",
 			Due:           deadline,
 			Board:         r.Properties.Status.Select.Name,
 			List:          "All",
 			ShortURL:      r.URL,
 			OriginalModel: nil,
-		}
+		})
 	}
 	return tasks
 }

--- a/app/presentation/rest/request.go
+++ b/app/presentation/rest/request.go
@@ -12,6 +12,12 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+// maxRequestBodySize : リクエストボディの最大サイズ（1MB）
+const maxRequestBodySize = 1 << 20
+
+// validate : バリデータのシングルトンインスタンス
+var validate = validator.New()
+
 // bindReqWithValidate : リクエスト内容を構造体にマッピングし、バリデーションを実施
 func bindReqWithValidate(ctx context.Context, src, dist any) error {
 	switch reflect.TypeOf(src) {
@@ -26,9 +32,7 @@ func bindReqWithValidate(ctx context.Context, src, dist any) error {
 	}
 
 	// TODO: バリデーションエラー専用のエラーレスポンスを用意
-	v := validator.New()
-	err := v.Struct(dist)
-	if err != nil {
+	if err := validate.Struct(dist); err != nil {
 		return fmt.Errorf("validation error > %w", err)
 	}
 	return nil
@@ -36,6 +40,7 @@ func bindReqWithValidate(ctx context.Context, src, dist any) error {
 
 // bindFromHTTPBody: リクエストボディの内容を構造体にマッピング
 func bindFromHTTPBody(ctx context.Context, r *http.Request, dist any) error {
+	r.Body = http.MaxBytesReader(nil, r.Body, maxRequestBodySize)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return fmt.Errorf("ioutil.ReadAll() > %w", err)
@@ -54,13 +59,6 @@ func bindFromHTTPBody(ctx context.Context, r *http.Request, dist any) error {
 func bindFromPathParams(ctx context.Context, src map[string]string, dist any) error {
 	if err := mapstructure.Decode(src, &dist); err != nil {
 		return fmt.Errorf("mapstructure.Decode() > %w", err)
-	}
-
-	// TODO: バリデーションエラー専用のエラーレスポンスを用意
-	v := validator.New()
-	err := v.Struct(dist)
-	if err != nil {
-		return fmt.Errorf("validate error > %w", err)
 	}
 
 	return nil

--- a/app/usecase/blog.go
+++ b/app/usecase/blog.go
@@ -8,6 +8,7 @@ import (
 	"github.com/yyh-gl/hobigon-golang-api-server/app/domain/gateway"
 	model "github.com/yyh-gl/hobigon-golang-api-server/app/domain/model/blog"
 	"github.com/yyh-gl/hobigon-golang-api-server/app/domain/repository"
+	"github.com/yyh-gl/hobigon-golang-api-server/app/log"
 )
 
 // ErrBlogNotFound : 該当Blogが存在しないエラー
@@ -75,10 +76,18 @@ func (b blog) Like(ctx context.Context, title string, isSilent bool) (model.Blog
 		return model.Blog{}, fmt.Errorf("blogRepository.Update()内でのエラー: %w", err)
 	}
 
-	// Slack に通知
+	// Slack に通知（リクエスト完了後も継続させるため context の cancel を切り離す）
 	if !isSilent {
+		notifyCtx := context.WithoutCancel(ctx)
 		go func() {
-			_ = b.sg.SendLikeNotification(ctx, blog)
+			defer func() {
+				if r := recover(); r != nil {
+					log.Error(notifyCtx, fmt.Errorf("panic in SendLikeNotification: %v", r))
+				}
+			}()
+			if err := b.sg.SendLikeNotification(notifyCtx, blog); err != nil {
+				log.Error(notifyCtx, fmt.Errorf("failed to SendLikeNotification: %w", err))
+			}
 		}()
 	}
 

--- a/cmd/rest/main.go
+++ b/cmd/rest/main.go
@@ -28,8 +28,12 @@ func main() {
 	router := newRouter(diContainer)
 
 	s := &http.Server{
-		Addr:    ":3000",
-		Handler: router,
+		Addr:              ":3000",
+		Handler:           router,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	errCh := make(chan error, 1)


### PR DESCRIPTION
## Summary
This PR refactors the Notion API integration to reduce code duplication, improves HTTP client configuration with timeouts, and adds defensive programming measures to prevent panics and improve error handling.

## Key Changes

### Notion API Refactoring (`app/infra/dao/task.go`)
- Extracted common Notion API request logic into a new `fetchTasks()` helper method to eliminate duplication between `FetchCautionAndToDoTasks()` and `FetchDeadTasks()`
- Created a module-level `notionHTTPClient` with a 10-second timeout instead of using `http.DefaultClient`
- Updated HTTP request creation to use `http.NewRequestWithContext()` for proper context propagation

### HTTP Server Hardening (`cmd/rest/main.go`)
- Added timeout configurations to the HTTP server:
  - `ReadHeaderTimeout`: 10 seconds
  - `ReadTimeout`: 30 seconds
  - `WriteTimeout`: 30 seconds
  - `IdleTimeout`: 120 seconds

### Request Handling Improvements (`app/presentation/rest/request.go`)
- Added `maxRequestBodySize` constant (1MB) to limit request body size
- Created a module-level `validate` singleton instance to avoid repeated validator instantiation
- Added `http.MaxBytesReader()` to enforce request body size limits in `bindFromHTTPBody()`
- Removed redundant validation from `bindFromPathParams()` (validation already occurs in `bindReqWithValidate()`)

### Notion DTO Robustness (`app/infra/dto/notion/task.go`)
- Changed task slice initialization from fixed-size to dynamic (`make(task.List, 0, len(dto.Results))`)
- Added defensive check to skip tasks with empty titles to prevent panics
- Refactored loop to use `append()` instead of index assignment for safer slice handling

### Slack Notification Reliability (`app/usecase/blog.go`)
- Improved async Slack notification handling in `Like()` method:
  - Used `context.WithoutCancel()` to allow notifications to complete even after request context cancellation
  - Added panic recovery with error logging
  - Added error logging for failed notifications

### Slack Message Formatting (`app/domain/model/slack/slack.go`)
- Added null-safety check for task due dates in `CreateTaskMessage()`
- Falls back to "なるはや" (ASAP) when due date is nil

## Implementation Details
- All changes maintain backward compatibility with existing interfaces
- Error handling is improved throughout with proper context propagation
- The refactoring reduces ~70 lines of duplicated code in the task DAO

https://claude.ai/code/session_017ewfwwnLjVZjc1TAga6LP8