### PR TITLE
Add domain model unit tests and refactor time injection

### DIFF
--- a/app/domain/model/blog/blog_test.go
+++ b/app/domain/model/blog/blog_test.go
@@ -1,0 +1,112 @@
+package blog_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/yyh-gl/hobigon-golang-api-server/app/domain/model/blog"
+	"github.com/yyh-gl/hobigon-golang-api-server/app/infra/dto"
+)
+
+func TestNewBlog(t *testing.T) {
+	tests := []struct {
+		name    string
+		title   string
+		wantErr bool
+	}{
+		{"正常系：1文字", "a", false},
+		{"正常系：50文字", strings.Repeat("a", 50), false},
+		{"異常系：51文字", strings.Repeat("a", 51), true},
+		{"正常系：空文字", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := blog.NewBlog(tt.title)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewBlog(%q) error = %v, wantErr %v", tt.title, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTitle_String(t *testing.T) {
+	tests := []struct {
+		title string
+		want  string
+	}{
+		{"hello", "hello"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		b, err := blog.NewBlog(tt.title)
+		if err != nil {
+			t.Fatalf("NewBlog(%q) unexpected error: %v", tt.title, err)
+		}
+		if got := b.Title().String(); got != tt.want {
+			t.Errorf("Title.String() = %q, want %q", got, tt.want)
+		}
+	}
+}
+
+func TestTitle_IsNull(t *testing.T) {
+	tests := []struct {
+		title string
+		want  bool
+	}{
+		{"", true},
+		{"hello", false},
+	}
+	for _, tt := range tests {
+		b, err := blog.NewBlog(tt.title)
+		if err != nil {
+			t.Fatalf("NewBlog(%q) unexpected error: %v", tt.title, err)
+		}
+		if got := b.Title().IsNull(); got != tt.want {
+			t.Errorf("Title.IsNull() = %v, want %v", got, tt.want)
+		}
+	}
+}
+
+func TestCount_IntAndString(t *testing.T) {
+	b, _ := blog.NewBlog("test")
+	if got := b.Count().Int(); got != 0 {
+		t.Errorf("Count.Int() = %d, want 0", got)
+	}
+	if got := b.Count().String(); got != "0" {
+		t.Errorf("Count.String() = %q, want \"0\"", got)
+	}
+}
+
+func TestBlog_CountUp(t *testing.T) {
+	b, _ := blog.NewBlog("test")
+	b = b.CountUp()
+	if got := b.Count().Int(); got != 1 {
+		t.Errorf("after 1 CountUp: Count = %d, want 1", got)
+	}
+	b = b.CountUp()
+	if got := b.Count().Int(); got != 2 {
+		t.Errorf("after 2 CountUp: Count = %d, want 2", got)
+	}
+}
+
+func TestBlog_CreateLikeMessage(t *testing.T) {
+	b, _ := blog.NewBlog("My Blog")
+	b = b.CountUp()
+	got := b.CreateLikeMessage()
+	want := "【My Blog】いいね！（Total: 1）"
+	if got != want {
+		t.Errorf("CreateLikeMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestConvertToEntity(t *testing.T) {
+	d := dto.BlogDTO{Title: "dto-title", Count: 5}
+	b := blog.ConvertToEntity(context.Background(), d)
+	if got := b.Title().String(); got != "dto-title" {
+		t.Errorf("Title = %q, want \"dto-title\"", got)
+	}
+	if got := b.Count().Int(); got != 5 {
+		t.Errorf("Count = %d, want 5", got)
+	}
+}

--- a/app/domain/model/pokemon/notification.go
+++ b/app/domain/model/pokemon/notification.go
@@ -32,13 +32,13 @@ func (n Notification) IsEventCategory() bool {
 	return n.category == "イベント"
 }
 
-func (n Notification) IsReceivedInToday() bool {
-	today := time.Now().Format("2006.1.2")
+func (n Notification) IsReceivedInToday(now time.Time) bool {
+	today := now.Format("2006.1.2")
 	return n.date == today
 }
 
-func (n Notification) IsReceivedInYesterday() bool {
-	yesterday := time.Now().Add(-24 * time.Hour).Format("2006.1.2")
+func (n Notification) IsReceivedInYesterday(now time.Time) bool {
+	yesterday := now.Add(-24 * time.Hour).Format("2006.1.2")
 	return n.date == yesterday
 }
 

--- a/app/domain/model/pokemon/notification_test.go
+++ b/app/domain/model/pokemon/notification_test.go
@@ -1,0 +1,86 @@
+package pokemon_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/yyh-gl/hobigon-golang-api-server/app/domain/model/pokemon"
+)
+
+func TestIsEventCategory(t *testing.T) {
+	tests := []struct {
+		category string
+		want     bool
+	}{
+		{"イベント", true},
+		{"大会", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		n := pokemon.NewNotification(tt.category, "title", "2024.1.1")
+		if got := n.IsEventCategory(); got != tt.want {
+			t.Errorf("IsEventCategory(%q) = %v, want %v", tt.category, got, tt.want)
+		}
+	}
+}
+
+func TestIsImportantEvent(t *testing.T) {
+	tests := []struct {
+		title string
+		want  bool
+	}{
+		{"シティリーグ予選", true},
+		{"シティリーグ", true},
+		{"通常大会", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		n := pokemon.NewNotification("イベント", tt.title, "2024.1.1")
+		if got := n.IsImportantEvent(); got != tt.want {
+			t.Errorf("IsImportantEvent(%q) = %v, want %v", tt.title, got, tt.want)
+		}
+	}
+}
+
+func TestIsReceivedInToday(t *testing.T) {
+	now := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		date string
+		want bool
+	}{
+		{"2024.6.15", true},
+		{"2024.6.14", false},
+		{"2024.6.16", false},
+	}
+	for _, tt := range tests {
+		n := pokemon.NewNotification("イベント", "title", tt.date)
+		if got := n.IsReceivedInToday(now); got != tt.want {
+			t.Errorf("IsReceivedInToday(%q) = %v, want %v", tt.date, got, tt.want)
+		}
+	}
+}
+
+func TestIsReceivedInYesterday(t *testing.T) {
+	now := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		date string
+		want bool
+	}{
+		{"2024.6.14", true},
+		{"2024.6.15", false},
+		{"2024.6.13", false},
+	}
+	for _, tt := range tests {
+		n := pokemon.NewNotification("イベント", "title", tt.date)
+		if got := n.IsReceivedInYesterday(now); got != tt.want {
+			t.Errorf("IsReceivedInYesterday(%q) = %v, want %v", tt.date, got, tt.want)
+		}
+	}
+}
+
+func TestTitle(t *testing.T) {
+	n := pokemon.NewNotification("イベント", "シティリーグ", "2024.6.15")
+	if got := n.Title(); got != "シティリーグ" {
+		t.Errorf("Title() = %q, want \"シティリーグ\"", got)
+	}
+}

--- a/app/domain/model/slack/slack_test.go
+++ b/app/domain/model/slack/slack_test.go
@@ -1,0 +1,68 @@
+package slack_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/yyh-gl/hobigon-golang-api-server/app/domain/model/slack"
+	"github.com/yyh-gl/hobigon-golang-api-server/app/domain/model/task"
+)
+
+func TestGetWebHookURL(t *testing.T) {
+	tests := []struct {
+		channel string
+		envKey  string
+		envVal  string
+		want    string
+	}{
+		{"00_today_tasks", "WEBHOOK_URL_TO_00", "https://hooks.slack.com/00", "https://hooks.slack.com/00"},
+		{"03_pokemon", "WEBHOOK_URL_TO_03", "https://hooks.slack.com/03", "https://hooks.slack.com/03"},
+		{"51_tech_blog", "WEBHOOK_URL_TO_51", "https://hooks.slack.com/51", "https://hooks.slack.com/51"},
+		{"unknown", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.channel, func(t *testing.T) {
+			if tt.envKey != "" {
+				t.Setenv(tt.envKey, tt.envVal)
+			}
+			s := slack.Slack{Channel: tt.channel}
+			if got := s.GetWebHookURL(); got != tt.want {
+				t.Errorf("GetWebHookURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateTaskMessage(t *testing.T) {
+	due := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+
+	cautionTasks := []task.Task{
+		{Title: "タスクA", ShortURL: "https://short.url/a", Due: &due},
+		{Title: "タスクB", ShortURL: "https://short.url/b", Due: nil},
+	}
+	deadTasks := []task.Task{
+		{Title: "タスクC", ShortURL: "https://short.url/c", Due: &due},
+	}
+
+	s := slack.Slack{Channel: "00_today_tasks"}
+	msg := s.CreateTaskMessage(cautionTasks, deadTasks)
+
+	checks := []struct {
+		desc string
+		sub  string
+	}{
+		{"Key Tasks 見出し", "Key Tasks"},
+		{"Dead Tasks 見出し", "Dead Tasks"},
+		{"cautionTask Dueあり", "2024-06-15"},
+		{"cautionTask Dueなし", "なるはや"},
+		{"連番1", "1:"},
+		{"連番2", "2:"},
+		{"deadTask title", "タスクC"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(msg, c.sub) {
+			t.Errorf("CreateTaskMessage() missing %s (%q)", c.desc, c.sub)
+		}
+	}
+}

--- a/app/domain/model/task/task.go
+++ b/app/domain/model/task/task.go
@@ -24,19 +24,17 @@ func (t Task) GetJSTDue(utcDue *time.Time) *time.Time {
 }
 
 // IsDueOver : 期限切れかどうか判定
-func (t Task) IsDueOver() (isDueOver bool) {
+func (t Task) IsDueOver(now time.Time) (isDueOver bool) {
 	jst := getJSTNow()
-	today := time.Now()
-	todayStart := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, jst)
+	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, jst)
 	return !t.Due.Equal(todayStart) && t.Due.Before(todayStart)
 }
 
 // IsTodayTask : 今日のタスクかどうか判定
-func (t Task) IsTodayTask() (isTodayTask bool) {
+func (t Task) IsTodayTask(now time.Time) (isTodayTask bool) {
 	jst := getJSTNow()
-	today := time.Now()
-	todayStart := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, jst)
-	todayEnd := time.Date(today.Year(), today.Month(), today.Day(), 23, 59, 59, 0, jst)
+	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, jst)
+	todayEnd := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, jst)
 	if t.Due != nil && t.Due.After(todayStart) && t.Due.Before(todayEnd) {
 		return true
 	}

--- a/app/domain/model/task/task_list.go
+++ b/app/domain/model/task/task_list.go
@@ -1,12 +1,14 @@
 package task
 
+import "time"
+
 // List : タスクリストを表すドメインモデル
 type List []Task
 
 // GetTodayTasks : タスクリストから今日のタスクを取得
-func (l List) GetTodayTasks() (todayTasks []Task) {
+func (l List) GetTodayTasks(now time.Time) (todayTasks []Task) {
 	for _, task := range l {
-		if task.IsTodayTask() {
+		if task.IsTodayTask(now) {
 			todayTasks = append(todayTasks, task)
 		}
 	}

--- a/app/domain/model/task/task_list_test.go
+++ b/app/domain/model/task/task_list_test.go
@@ -1,0 +1,32 @@
+package task_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/yyh-gl/hobigon-golang-api-server/app/domain/model/task"
+)
+
+func TestList_GetTodayTasks(t *testing.T) {
+	jst := time.FixedZone("Asia/Tokyo", 9*60*60)
+	now := time.Date(2024, 6, 15, 10, 0, 0, 0, jst)
+
+	todayDue := time.Date(2024, 6, 15, 12, 0, 0, 0, jst)
+	yesterdayDue := time.Date(2024, 6, 14, 12, 0, 0, 0, jst)
+	tomorrowDue := time.Date(2024, 6, 16, 12, 0, 0, 0, jst)
+
+	list := task.List{
+		{Title: "今日のタスク", Due: &todayDue},
+		{Title: "昨日のタスク", Due: &yesterdayDue},
+		{Title: "明日のタスク", Due: &tomorrowDue},
+		{Title: "Dueなし", Due: nil},
+	}
+
+	got := list.GetTodayTasks(now)
+	if len(got) != 1 {
+		t.Fatalf("GetTodayTasks() len = %d, want 1", len(got))
+	}
+	if got[0].Title != "今日のタスク" {
+		t.Errorf("GetTodayTasks()[0].Title = %q, want \"今日のタスク\"", got[0].Title)
+	}
+}

--- a/app/domain/model/task/task_test.go
+++ b/app/domain/model/task/task_test.go
@@ -1,0 +1,82 @@
+package task_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/yyh-gl/hobigon-golang-api-server/app/domain/model/task"
+)
+
+func jst() *time.Location {
+	return time.FixedZone("Asia/Tokyo", 9*60*60)
+}
+
+func TestGetJSTDue(t *testing.T) {
+	utc := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	tsk := task.Task{Due: &utc}
+	got := tsk.GetJSTDue(&utc)
+	wantHour := 9
+	if got.Hour() != wantHour {
+		t.Errorf("GetJSTDue hour = %d, want %d", got.Hour(), wantHour)
+	}
+	if got.Location().String() != "Asia/Tokyo" {
+		t.Errorf("GetJSTDue location = %q, want \"Asia/Tokyo\"", got.Location().String())
+	}
+}
+
+func TestIsDueOver(t *testing.T) {
+	jst := jst()
+	now := time.Date(2024, 6, 15, 10, 0, 0, 0, jst)
+
+	past := time.Date(2024, 6, 14, 12, 0, 0, 0, jst)
+	today := time.Date(2024, 6, 15, 12, 0, 0, 0, jst)
+	future := time.Date(2024, 6, 16, 12, 0, 0, 0, jst)
+	todayStart := time.Date(2024, 6, 15, 0, 0, 0, 0, jst)
+
+	tests := []struct {
+		name string
+		due  *time.Time
+		want bool
+	}{
+		{"過去", &past, true},
+		{"今日の途中", &today, false},
+		{"未来", &future, false},
+		{"今日の開始（equal）", &todayStart, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tsk := task.Task{Due: tt.due}
+			if got := tsk.IsDueOver(now); got != tt.want {
+				t.Errorf("IsDueOver() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTodayTask(t *testing.T) {
+	jst := jst()
+	now := time.Date(2024, 6, 15, 10, 0, 0, 0, jst)
+
+	todayMid := time.Date(2024, 6, 15, 12, 0, 0, 0, jst)
+	yesterday := time.Date(2024, 6, 14, 12, 0, 0, 0, jst)
+	tomorrow := time.Date(2024, 6, 16, 12, 0, 0, 0, jst)
+
+	tests := []struct {
+		name string
+		due  *time.Time
+		want bool
+	}{
+		{"今日のタスク", &todayMid, true},
+		{"昨日のタスク", &yesterday, false},
+		{"明日のタスク", &tomorrow, false},
+		{"Due nil", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tsk := task.Task{Due: tt.due}
+			if got := tsk.IsTodayTask(now); got != tt.want {
+				t.Errorf("IsTodayTask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/app/presentation/rest/blog_test.go
+++ b/app/presentation/rest/blog_test.go
@@ -175,7 +175,6 @@ func TestBlogHandler_Like(t *testing.T) {
 			},
 		},
 		{ // 異常系：51文字タイトル
-			// TODO: ドメインモデル用テストを作って、NewTitle()におけるバリデーションが動作するか確認
 			title: "hoge-hoge-hoge-hoge-hoge-hoge-hoge-hoge-hoge-title-over",
 			want: want{
 				body:       `{"error":{"detail":"不正なリクエスト形式です"}}`,

--- a/app/usecase/notification.go
+++ b/app/usecase/notification.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/yyh-gl/hobigon-golang-api-server/app/domain/gateway"
@@ -91,6 +92,7 @@ func crawlNotifications() ([]pokemon.Notification, error) {
 }
 
 func extractNewEventNotifications(notifications []pokemon.Notification) []pokemon.Notification {
+	now := time.Now()
 	existenceMap := make(map[string]struct{})
 	events := make([]pokemon.Notification, 0, len(notifications))
 	for _, n := range notifications {
@@ -102,7 +104,7 @@ func extractNewEventNotifications(notifications []pokemon.Notification) []pokemo
 			continue
 		}
 
-		if n.IsReceivedInToday() || n.IsReceivedInYesterday() {
+		if n.IsReceivedInToday(now) || n.IsReceivedInYesterday(now) {
 			events = append(events, n)
 			existenceMap[n.Title()] = struct{}{}
 		}


### PR DESCRIPTION
- Add table-driven unit tests for blog, pokemon, task, slack domain models
- Refactor IsDueOver/IsTodayTask/GetTodayTasks to accept now time.Time parameter
- Refactor IsReceivedInToday/IsReceivedInYesterday to accept now time.Time parameter
- Update usecase/notification.go caller to pass time.Now() explicitly
- Remove resolved TODO comment from blog_test.go

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L3e2eEWPUpLBWMVHixWPpT