### PR TITLE
deploy_to_gce ジョブを復活

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -122,9 +122,73 @@ jobs:
         with:
           args: set image -n hobigon deployment/hobigon-api-deployment hobigon-api=${{ env.TAG }}
 
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+      - uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Set VERSION environment
+        env:
+          REF: ${{ github.ref }}
+        run: echo "VERSION=${REF##*/}" >> $GITHUB_ENV
+      - name: Build
+        run: make build-all version=${{ env.VERSION }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binaries
+          path: |
+            ./cmd/rest/bin/api-server
+            ./cmd/cli/bin/hobi
+            ./cmd/graphql/bin/graphql-server
+          retention-days: 1
+          if-no-files-found: error
+
+  deploy_to_gce:
+    name: Deploy to GCE
+    runs-on: ubuntu-latest
+    needs: [ create_release_note, build ]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: binaries
+          path: cmd
+      - name: Deploy
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          port: ${{ secrets.SSH_PORT }}
+          key: ${{ secrets.SSH_KEY }}
+          source: cmd
+          target: api-server-golang
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          name: id_rsa
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+          config: ${{ secrets.SSH_CONFIG }}
+      - name: Restart server
+        run: |
+          ssh hobigon sudo chmod +x /home/Y_h/api-server-golang/cmd/{cli,graphql,rest}/bin/*
+          ssh hobigon sudo systemctl restart api-server-golang.service
+
   success_notification:
     name: Success notification
-    needs: [ publish_container_image_latest_version, deploy_to_k8s ]
+    needs: [ publish_container_image_latest_version, deploy_to_k8s, deploy_to_gce ]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -138,7 +202,7 @@ jobs:
 
   failure_notification:
     name: Failure notification
-    needs: [ publish_container_image_latest_version, deploy_to_k8s ]
+    needs: [ publish_container_image_latest_version, deploy_to_k8s, deploy_to_gce ]
     runs-on: ubuntu-latest
     if: always()
     steps:


### PR DESCRIPTION
8042dfef 時点の deployment.yml にあった build / deploy_to_gce ジョブを
復元し、通知ジョブの needs に deploy_to_gce を追加。
アクションのバージョンは現行ファイルに合わせて更新
（checkout@v7, setup-go@v6, cache@v4）。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KpwuiShDRBLoZTBSAiqacR